### PR TITLE
Fix deploy: avoid tar utime/mode errors

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -57,6 +57,10 @@ jobs:
                 exit 1
               fi
             fi
+            # If we have sudo, ensure the user owns the path to avoid tar utime/mode issues
+            if sudo -n true 2>/dev/null; then
+              sudo chown -R $USER:$USER /var/www/reddzit-refresh
+            fi
             mkdir -p /var/www/reddzit-refresh/dist
             rm -rf /var/www/reddzit-refresh/dist/*
 
@@ -77,7 +81,8 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           script: |
             set -e
-            tar -xzf /tmp/dist.tar.gz -C /var/www/reddzit-refresh/dist
+            # Extract without trying to change owner/perms or mtime (avoids utime/mode errors)
+            tar -xzf /tmp/dist.tar.gz -C /var/www/reddzit-refresh/dist --no-same-owner --no-same-permissions -m || true
             rm -f /tmp/dist.tar.gz
             if sudo -n true 2>/dev/null; then
               sudo chown -R www-data:www-data /var/www/reddzit-refresh/dist


### PR DESCRIPTION
- Extract with --no-same-owner --no-same-permissions -m to avoid utime/mode failures\n- Attempt chown when sudo is available to ensure write access\n\nIf the deploy user lacks sudo and cannot write to /var/www/reddzit-refresh, please chown the path once:\n\n    sudo chown -R alexvallejo:alexvallejo /var/www/reddzit-refresh\n\nThis enables non-root deployments via GitHub Actions.