### PR TITLE
Fix deploy secret name (SSH_KEY)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Start SSH agent and add key
         uses: webfactory/ssh-agent@v0.8.0
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key: ${{ secrets.SSH_KEY }}
 
       - name: Add host to known_hosts
         run: |


### PR DESCRIPTION
Switch deploy workflow to use secrets.SSH_KEY instead of secrets.SSH_PRIVATE_KEY to match README and deploy-frontend.yml.\n\nThis resolves: 'The ssh-private-key argument is empty' during deploy because the expected secret name was mismatched.