### PR TITLE
Canonical share URLs + auto-navigation to /reddit?name=…

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,16 @@ How it works:
 - Nginx proxies only `/p/` requests to read-api (port 3000 by default).
 - read-api injects `<title>`, `og:*`, and Twitter tags into `index.html` at request time using the built assets from this repo.
 
+Canonical share URL:
+- Use `/p/:fullname` (e.g., `https://reddzit.seojeek.com/p/t3_abcdef`).
+
 What the frontend must do:
 - Continue deploying the built `dist/` to the path configured in read-api (`FRONTEND_DIST_DIR`, e.g., `/var/www/reddzit-refresh/dist`).
 - Ensure “Copy Share Link” buttons generate URLs of the form `/p/<full_name>` (already implemented).
+- The `/p/:fullname` route auto-navigates to `/reddit?name=:fullname` for human users; bots see SSR’d tags.
+
+Backward compatibility suggestion (nginx):
+- Redirect old links `GET /reddit?name=<fullname>` → `301 /p/<fullname>` so social bots hit the canonical path.
 
 Server-side setup is documented in the read-api repo. In short:
 - Set `FRONTEND_DIST_DIR` and `PUBLIC_BASE_URL` in read-api.


### PR DESCRIPTION
Overview

Align frontend with canonical share URLs and read-api SSR. Users share `/p/:fullname`; bots get SSR'd meta from read-api; humans are auto-navigated to the app route that expects `name`.

Changes
- Route: add `/p/:fullname` (`PostView`).
- Auto-navigation: when users visit `/p/:fullname`, navigate to `/reddit?name=:fullname`; bots won't execute JS and will use SSR meta from read-api.
- Share links: update copy buttons to use `/p/<full_name>` and label as “Copy Share Link”.
- Docs: clarify canonical pattern and suggest nginx redirect from `/reddit?name=` → `/p/:name`.

How SSR works (handled by read-api)
- Nginx proxies only `/p/…` to read-api.
- read-api injects `<title>`, OG/Twitter tags into the frontend's built `index.html`.
- Frontend continues to deploy `dist/` to the server path configured as `FRONTEND_DIST_DIR`.

Test plan
- Visit `/p/t3_<id>` locally: confirm the app auto-navigates to `/reddit?name=t3_<id>`
- Check deployed share previews: paste a `/p/t3_<id>` link into Slack/Discord; verify title/image.

Notes
- No frontend Node server; SSR is in read-api (see read-api PR #1).
- CI already restarts read-api after frontend deploy so SSR reads updated `index.html`.
