### PR TITLE
Adopt Outfit as default font; keep site title in Zilla Slab

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -4,6 +4,7 @@
 @import '../node_modules/spectre.css/src/spectre';
 @import url('https://fonts.googleapis.com/css?family=Zilla+Slab');
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,600,700,Montserrat:600i,Lato:100i');
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap');
 
 @import './styles/layout';
 @import './styles/off-canvas';

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -74,7 +74,7 @@
         justify-content: center;
         align-items: center;
 
-        font-family: 'Zilla Slab', 'serif';
+        font-family: 'Outfit', sans-serif;
         font-size: 22px;
         text-align: center;
     }
@@ -97,7 +97,7 @@
 body {
     margin: 0;
     padding: 0;
-    font-family: 'Open Sans', sans-serif;
+    font-family: 'Outfit', sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     color: #5d5d5d;
@@ -162,6 +162,7 @@ code {
             a {
                 margin: 0 15px;
                 padding: 0 30px;
+                font-family: 'Outfit', sans-serif;
                 &:hover {
                     color: $dark-primary;
                 }

--- a/src/styles/off-canvas.scss
+++ b/src/styles/off-canvas.scss
@@ -29,7 +29,7 @@
 .read-content {
     width: 51%;
 
-    font-family: 'Zilla Slab', serif;
+    font-family: 'Outfit', sans-serif;
     font-size: 18px;
 
     // .read-controls-wrapper.darkMode ~ .read-content-inner {
@@ -197,5 +197,5 @@ html,
 body {
     height: 100%;
     width: 100%;
-    font-family: Helvetica, Arial, sans-serif;
+    font-family: 'Outfit', sans-serif;
 }

--- a/src/styles/post-view.scss
+++ b/src/styles/post-view.scss
@@ -25,6 +25,12 @@
   background: $primary-color; /* same purple as app */
 }
 
+/* Ensure hero title uses app font */
+.public-post .post-title h2,
+.public-post .post-title a {
+  font-family: 'Outfit', sans-serif;
+}
+
 /* Centered reading area */
 .public-post .content {
   max-width: 1000px;
@@ -80,3 +86,4 @@
   background: $darkMode !important;
   color: $darkModeFont;
 }
+


### PR DESCRIPTION
Changes:
- Make Outfit default across app
- Keep “Reddzit” site title in Zilla Slab
- Remove font toggle and related code
- Apply Outfit to nav links and post hero titles

Notes:
- Imports Google Fonts for Outfit and Zilla Slab