### PR TITLE
Rotate clickable top comments under magazine grid headlines

### DIFF
--- a/src/components/MagazineGrid.tsx
+++ b/src/components/MagazineGrid.tsx
@@ -1,9 +1,21 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faForward } from '@fortawesome/free-solid-svg-icons';
-import type { TrendingPost } from '../helpers/DailyService';
+import type { TrendingPost, TrendingPostTopComment } from '../helpers/DailyService';
 import { useTheme } from '../context/ThemeContext';
 import { getDisplayTitle } from '../helpers/RedditUtils';
+
+const QUOTE_ROTATE_MS = 7000;
+const QUOTE_FADE_MS = 400;
+
+const shuffleComments = (comments: TrendingPostTopComment[]): TrendingPostTopComment[] => {
+  const arr = [...comments];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+};
 
 type TileSize = 'hero' | 'tall' | 'standard';
 
@@ -54,21 +66,74 @@ const MetaRow = ({ post }: { post: TrendingPost }) => {
 };
 
 const Quote = ({ post }: { post: TrendingPost }) => {
-  if (post.topComment) {
+  const comments = useMemo(
+    () => (post.topComments?.length ? shuffleComments(post.topComments) : []),
+    [post.topComments]
+  );
+
+  const [index, setIndex] = useState(0);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (comments.length <= 1) return;
+    const stagger = (post.id.charCodeAt(0) % 5) * 700;
+    let interval: ReturnType<typeof setInterval> | null = null;
+    let fadeTimeout: ReturnType<typeof setTimeout> | null = null;
+    const startTimeout = setTimeout(() => {
+      interval = setInterval(() => {
+        setVisible(false);
+        fadeTimeout = setTimeout(() => {
+          setIndex((i) => (i + 1) % comments.length);
+          setVisible(true);
+        }, QUOTE_FADE_MS);
+      }, QUOTE_ROTATE_MS);
+    }, stagger);
+    return () => {
+      clearTimeout(startTimeout);
+      if (fadeTimeout) clearTimeout(fadeTimeout);
+      if (interval) clearInterval(interval);
+    };
+  }, [comments.length, post.id]);
+
+  if (comments.length === 0) {
+    if (post.selftext) {
+      return (
+        <p className="text-xs text-[var(--theme-textMuted)] line-clamp-3 mt-2">
+          {post.selftext}
+        </p>
+      );
+    }
+    return null;
+  }
+
+  const current = comments[index];
+  const baseClass = 'block text-xs italic text-[var(--theme-textMuted)] line-clamp-3 mt-2 transition-opacity';
+  const style = { opacity: visible ? 1 : 0, transitionDuration: `${QUOTE_FADE_MS}ms` };
+  const inner = (
+    <>
+      “{current.body}” <span className="not-italic">— u/{current.author}</span>
+    </>
+  );
+
+  if (current.permalink) {
     return (
-      <p className="text-xs italic text-[var(--theme-textMuted)] line-clamp-3 mt-2">
-        “{post.topComment.body}” <span className="not-italic">— u/{post.topComment.author}</span>
-      </p>
+      <a
+        href={`https://www.reddit.com${current.permalink}`}
+        target="_blank"
+        rel="noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        className={`${baseClass} hover:text-[var(--theme-primary)] no-underline`}
+        style={style}
+      >
+        {inner}
+      </a>
     );
   }
-  if (post.selftext) {
-    return (
-      <p className="text-xs text-[var(--theme-textMuted)] line-clamp-3 mt-2">
-        {post.selftext}
-      </p>
-    );
-  }
-  return null;
+  return (
+    <p className={baseClass} style={style}>
+      {inner}
+    </p>
+  );
 };
 
 const SkipButton = ({ onSkip }: { onSkip: () => void }) => {

--- a/src/helpers/DailyService.ts
+++ b/src/helpers/DailyService.ts
@@ -37,14 +37,16 @@ export interface DailyReport {
 
 const CACHE_KEY = 'rdz_latest_report';
 const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes
-const RSS_CACHE_KEY = 'rdz_trending_rss';
+const RSS_CACHE_KEY = 'rdz_trending_rss_v2';
 const RSS_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 const RSS_STALE_FALLBACK_MAX_AGE = 60 * 60 * 1000; // 60 minutes
 
 export interface TrendingPostTopComment {
+  id: string;
   body: string;
   author: string;
   score: number;
+  permalink: string | null;
 }
 
 export interface TrendingPost {
@@ -59,7 +61,7 @@ export interface TrendingPost {
   score?: number;
   numComments?: number;
   postHint?: string;
-  topComment?: TrendingPostTopComment;
+  topComments?: TrendingPostTopComment[];
 }
 
 const DailyService = {


### PR DESCRIPTION
## Summary
- Magazine grid cards now shuffle the post's top comments and rotate one quote at a time with a 400ms fade and 7s display, staggered per card by post-id hash so they don't all flip in unison.
- Each rotating quote is a `target="_blank"` link to the comment's reddit.com permalink (`stopPropagation` prevents the card click from firing).
- `TrendingPost.topComment` → `topComments: TrendingPostTopComment[]` to match the new backend shape (companion read-api PR).
- Bumps `RSS_CACHE_KEY` to `rdz_trending_rss_v2` so stale browser caches get evicted on first load after deploy.

## Test plan
- [ ] Visit `/news`, confirm magazine cards show italic quote under headline
- [ ] Wait ~7s, confirm quotes fade-rotate to a different comment per card
- [ ] Confirm cards rotate at staggered times (not all flipping simultaneously)
- [ ] Click a quote → opens the comment's reddit.com permalink in a new tab; card click is not triggered
- [ ] Posts with no comments fall back to selftext or render nothing
- [ ] No console errors / type errors (`yarn build` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)